### PR TITLE
Improve path finding

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -371,7 +371,17 @@ script.on_event(defines.events.on_tick, function(event)
 
         if nearest_entity and not player_state.parameters.calculating_path and not player_state.parameters.path then
             local character = player.character
-            local bbox = {{character.position.x, character.position.y},{character.position.x, character.position.y}}
+             -- TODO: improve path following
+             -- currently using larger than character bbox as a workaround for the path following getting stuck on objects
+             -- may sometimes still get stuck on trees and will fail to find small passages
+            local bbox = {{-0.5, -0.5}, {0.5, 0.5}}
+            local start = player.surface.find_non_colliding_position(
+                "iron-chest", -- TODO: using iron chest bbox so request_path doesn't fail standing near objects using the larger bbox
+                character.position,
+                10,
+                0.5,
+                false
+            )
             player.surface.request_path{
                 bounding_box = bbox,
                 collision_mask = {
@@ -382,15 +392,15 @@ script.on_event(defines.events.on_tick, function(event)
                     "object-layer"
                 },
                 radius = 2,
-                start = character.position,
+                start = start,
                 goal = nearest_entity.position,
                 force = player.force,
                 entity_to_ignore = character,
                 pathfind_flags = {
                     cache = false,
                     no_break = true,
-                    prefer_straight_paths = true,
-                    allow_paths_through_own_entities = true
+                    prefer_straight_paths = false,
+                    allow_paths_through_own_entities = false
                 }
             }
             player_state.parameters.calculating_path = true


### PR DESCRIPTION
**What**
Path finding was not working properly but can now navigate through most forests and mazes.

![Forest path finding](https://github.com/user-attachments/assets/f7d4d7c6-f484-43e3-ba5d-d4f198401ad3)
![Maze path finding](https://github.com/user-attachments/assets/8772ec69-6636-4e72-9442-70a965dd8e09)

**Why**
Factorio's `request_path` expects `bounding_box` to be centered on (0, 0) but it was set to `{{character.position.x, character.position.y},{character.position.x, character.position.y}}` so it was not finding the correct paths.

Path following also gets caught on objects because it cannot navigate around collision corners.

**Changes**
1. Set the bounding box to `{{-0.5, -0.5}, {0.5, 0.5}}` to find the correct paths and roughly ~2.5x bigger than the character to increase the probability of finding a path that the path following does not get stuck on.
2. Added an additional step to find a non-colliding starting position so path finding does not fail when a path should be available.
3. Set `allow_paths_through_own_entities = false` so it does not try to path through own entities built.
4. Set `prefer_straight_paths = false` since it generates shorter and cleaner paths.

**Future work**
* Improve the path following so the bounding box can be set to the character's default to allow navigation through smaller passages such as dense forests.
